### PR TITLE
feat: add unlabeled bucket to labeling page and allow assigning unlabeled images

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -382,3 +382,14 @@ btn-info:hover {
     font-size: 0.875rem;
     line-height: 1.5;
 }
+
+/* Labeling page: make the "Unlabeled" bucket row stand out from Classes rows.
+   !important needed to win over Bootstrap's .table-striped nth-of-type background. */
+.unlabeled-row {
+    background-color: rgba(21, 105, 174, 0.08) !important;
+    border-left: 4px solid #1569AE;
+}
+
+.unlabeled-row a {
+    font-weight: bold;
+}

--- a/routes/labelling/switchLabels.js
+++ b/routes/labelling/switchLabels.js
@@ -1,5 +1,6 @@
 const queries = require("../../queries/queries");
 const path = require("path");
+const UNLABELED_CLASS = require("../../utils/unlabeledClass");
 
 async function switchLabels(req, res) {
     try {
@@ -46,6 +47,37 @@ async function switchLabels(req, res) {
         if (!selectedClass || !currentClass) {
             return res.status(400).json({
                 message: "Missing class information"
+            });
+        }
+
+        if (currentClass === UNLABELED_CLASS) {
+            // Unlabeled images have no existing Labels row (no LID) to UPDATE,
+            // so assigning them a class is an INSERT keyed by image name instead.
+            let changes = 0;
+            for (const imageName of labelsArray) {
+                const insertSql =
+                    "INSERT INTO Labels (LID, CName, X, Y, W, H, IName) VALUES (NULL, ?, '0', '0', 0, 0, ?)";
+                const insertResult = await queries.project.sql(
+                    projectPath,
+                    insertSql,
+                    [selectedClass, imageName],
+                );
+
+                if (insertResult.error) {
+                    global.logger.error("SQL Error:", insertResult.error);
+                    return res.status(500).json({
+                        message: "Database error occurred",
+                        error: insertResult.error,
+                    });
+                }
+
+                changes += insertResult.changes || 0;
+            }
+
+            return res.json({
+                message: "Images assigned to class successfully",
+                labelsAffected: changes,
+                body: req.body,
             });
         }
 

--- a/routes/pages/getLabelingPage.js
+++ b/routes/pages/getLabelingPage.js
@@ -1,3 +1,5 @@
+const UNLABELED_CLASS = require("../../utils/unlabeledClass");
+
 async function getLabelingPage(req, res) {
     var username = req.cookies.Username;
     var IDX = parseInt(req.query.IDX, 10);
@@ -149,6 +151,11 @@ async function getLabelingPage(req, res) {
     var results5 = await sdb.getAsync("SELECT COUNT(*) FROM Images");
     var results6 = await sdb.allAsync("SELECT DISTINCT IName FROM Labels");
 
+    var unlabeledCountQuery = await sdb.getAsync(
+        "SELECT COUNT(*) as count FROM Images WHERE IName NOT IN (SELECT IName FROM Labels)",
+    );
+    var unlabeledCount = unlabeledCountQuery ? unlabeledCountQuery.count : 0;
+
     sdb.close(function (err) {
         if (err) {
             global.logger.error(err);
@@ -164,6 +171,8 @@ async function getLabelingPage(req, res) {
         classes: Classes || [],
         IDX: IDX,
         lcounts: lcounts,
+        unlabeledCount: unlabeledCount,
+        unlabeledClass: UNLABELED_CLASS,
         activePage: "Label",
     });
 }

--- a/routes/pages/getReviewPage.js
+++ b/routes/pages/getReviewPage.js
@@ -1,7 +1,10 @@
+const UNLABELED_CLASS = require("../../utils/unlabeledClass");
+
 async function getReviewPage(req, res) {
     var username = req.cookies.Username;
     var CName = req.query.class;
     var IDX = req.query.IDX;
+    var isUnlabeledMode = CName === UNLABELED_CLASS;
 
     var page = parseInt(req.query.page) || 1;
     var pageSize = 100;
@@ -54,26 +57,50 @@ async function getReviewPage(req, res) {
         });
     };
 
-    var totalImages = await pdb.allAsync(
-        `
-			SELECT COUNT(*) as count 
-			FROM Images
-			INNER JOIN Labels ON Images.IName = Labels.IName
-			WHERE Labels.CName = ?
-		`,
-        [CName],
-    );
+    var totalImages;
+    var images;
 
-    var images = await pdb.allAsync(
-        `
-			SELECT Images.IName
-			FROM Images
-			INNER JOIN Labels ON Images.IName = Labels.IName
-			WHERE Labels.CName = ?
-			LIMIT ? OFFSET ?
-		`,
-        [CName, pageSize, offset],
-    );
+    if (isUnlabeledMode) {
+        // Unlabeled bucket: images with zero rows in Labels at all.
+        totalImages = await pdb.allAsync(
+            `
+				SELECT COUNT(*) as count
+				FROM Images
+				WHERE Images.IName NOT IN (SELECT IName FROM Labels)
+			`,
+        );
+
+        images = await pdb.allAsync(
+            `
+				SELECT Images.IName
+				FROM Images
+				WHERE Images.IName NOT IN (SELECT IName FROM Labels)
+				LIMIT ? OFFSET ?
+			`,
+            [pageSize, offset],
+        );
+    } else {
+        totalImages = await pdb.allAsync(
+            `
+				SELECT COUNT(*) as count
+				FROM Images
+				INNER JOIN Labels ON Images.IName = Labels.IName
+				WHERE Labels.CName = ?
+			`,
+            [CName],
+        );
+
+        images = await pdb.allAsync(
+            `
+				SELECT Images.IName
+				FROM Images
+				INNER JOIN Labels ON Images.IName = Labels.IName
+				WHERE Labels.CName = ?
+				LIMIT ? OFFSET ?
+			`,
+            [CName, pageSize, offset],
+        );
+    }
 
     let uniqueImages = images.filter(
         (image, index, self) =>
@@ -108,6 +135,9 @@ async function getReviewPage(req, res) {
     res.render("review", {
         user: username,
         CName: CName,
+        displayClassName: isUnlabeledMode ? "Unlabeled" : CName,
+        isUnlabeledMode: isUnlabeledMode,
+        unlabeledClass: UNLABELED_CLASS,
         images: uniqueImages,
         imageLabels: imageLabels,
         PName: PName, // Added PName to the render call

--- a/tests/integration/unlabeledLabelingPage.test.js
+++ b/tests/integration/unlabeledLabelingPage.test.js
@@ -1,0 +1,68 @@
+// Regression test for the "unlabeled" bucket on the labeling page: images with zero rows in
+// Labels must be counted and reported separately from the Classes-driven rows, without being
+// folded into any class's count.
+
+const UNLABELED_CLASS = require('../../utils/unlabeledClass');
+
+describe('GET /labeling - unlabeled bucket', () => {
+  let getLabelingPage;
+
+  beforeAll(() => {
+    global.logger = { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    global.currentPath = '/test/path/';
+
+    global.db = {
+      allAsync: jest.fn().mockResolvedValue([
+        { PName: 'test-project', Admin: 'testuser', Username: 'testuser' },
+      ]),
+      getAsync: jest.fn().mockResolvedValue({}),
+    };
+
+    global.sqlite3 = {
+      Database: jest.fn((dbPath, cb) => {
+        if (typeof cb === 'function') cb(null);
+        return {
+          all: jest.fn((sql, cb2) => {
+            if (sql.includes('Classes')) {
+              return cb2(null, [{ CName: 'cat' }]);
+            }
+            return cb2(null, []);
+          }),
+          get: jest.fn((sql, cb2) => {
+            if (sql.includes('NOT IN (SELECT IName FROM Labels)')) {
+              return cb2(null, { count: 4 });
+            }
+            if (sql.includes('COUNT(*) FROM Labels WHERE CName')) {
+              return cb2(null, { 'COUNT(*)': 7 });
+            }
+            if (sql.includes('COUNT(*) FROM Images')) {
+              return cb2(null, { 'COUNT(*)': 11 });
+            }
+            return cb2(null, {});
+          }),
+          close: jest.fn((cb2) => cb2 && cb2()),
+        };
+      }),
+    };
+
+    getLabelingPage = require('../../routes/pages/getLabelingPage');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports the count of images with zero Labels rows as a separate unlabeled bucket', async () => {
+    const req = { query: { IDX: '0' }, cookies: { Username: 'testuser' } };
+    const res = { render: jest.fn(), redirect: jest.fn() };
+
+    await getLabelingPage(req, res);
+
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(res.render).toHaveBeenCalledWith('labeling', expect.objectContaining({
+      classes: [{ CName: 'cat' }],
+      unlabeledCount: 4,
+      unlabeledClass: UNLABELED_CLASS,
+    }));
+  });
+});

--- a/tests/integration/unlabeledReviewPage.test.js
+++ b/tests/integration/unlabeledReviewPage.test.js
@@ -1,0 +1,72 @@
+// Regression test for the "unlabeled" bucket's redirect target: clicking the bucket on the
+// labeling page sends the user to /review?class=<sentinel>, which must select Images with no
+// matching Labels row at all (the normal INNER JOIN ... WHERE Labels.CName = ? path returns
+// nothing for those images, since they have no Labels row to join against).
+
+const UNLABELED_CLASS = require('../../utils/unlabeledClass');
+
+describe('GET /review - unlabeled bucket', () => {
+  let getReviewPage;
+
+  beforeAll(() => {
+    global.logger = { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    global.currentPath = '/test/path/';
+
+    global.db = {
+      allAsync: jest.fn().mockResolvedValue([
+        { PName: 'test-project', Admin: 'testuser', Username: 'testuser' },
+      ]),
+    };
+
+    global.sqlite3 = {
+      Database: jest.fn((dbPath, cb) => {
+        if (typeof cb === 'function') cb(null);
+        return {
+          all: jest.fn((sql, params, cb2) => {
+            if (sql.includes('COUNT(*) as count') && sql.includes('NOT IN (SELECT IName FROM Labels)')) {
+              return cb2(null, [{ count: 2 }]);
+            }
+            if (sql.includes('Images.IName') && sql.includes('NOT IN (SELECT IName FROM Labels)')) {
+              return cb2(null, [{ IName: 'unlabeled1.jpg' }, { IName: 'unlabeled2.jpg' }]);
+            }
+            if (sql.includes('SELECT * FROM Labels WHERE IName')) {
+              return cb2(null, []);
+            }
+            if (sql.includes('Classes')) {
+              return cb2(null, [{ CName: 'cat' }]);
+            }
+            // The old INNER JOIN ... WHERE Labels.CName = ? path falls through to here and
+            // returns no images - which is exactly the bug this test guards against.
+            return cb2(null, []);
+          }),
+          close: jest.fn((cb2) => cb2 && cb2()),
+        };
+      }),
+    };
+
+    getReviewPage = require('../../routes/pages/getReviewPage');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('selects images with no Labels row and renders the review page in unlabeled mode', async () => {
+    const req = {
+      query: { class: UNLABELED_CLASS, IDX: '0' },
+      cookies: { Username: 'testuser' },
+    };
+    const res = { render: jest.fn(), redirect: jest.fn() };
+
+    await getReviewPage(req, res);
+
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(res.render).toHaveBeenCalledWith('review', expect.objectContaining({
+      isUnlabeledMode: true,
+      displayClassName: 'Unlabeled',
+      unlabeledClass: UNLABELED_CLASS,
+      images: [{ IName: 'unlabeled1.jpg' }, { IName: 'unlabeled2.jpg' }],
+      totalPageCount: 1,
+    }));
+  });
+});

--- a/tests/integration/unlabeledSwitchLabels.test.js
+++ b/tests/integration/unlabeledSwitchLabels.test.js
@@ -1,0 +1,84 @@
+// Regression test for assigning a previously-unlabeled image to a class. Unlabeled images have
+// no Labels row (no LID), so the normal switchLabels UPDATE ... WHERE LID IN (...) path can never
+// match them - assigning a class must INSERT a new Labels row instead, keyed by image name.
+//
+// Invokes the route handler directly (bypassing the Express app) since requiring app.js pulls in
+// node-fetch@3 (ESM-only), which Jest in this repo isn't configured to transform.
+
+const UNLABELED_CLASS = require('../../utils/unlabeledClass');
+
+jest.mock('../../queries/queries', () => ({
+  project: {
+    sql: jest.fn(),
+  },
+}));
+
+const queries = require('../../queries/queries');
+const switchLabels = require('../../routes/labelling/switchLabels');
+
+describe('switchLabels - assign a previously-unlabeled image to a class', () => {
+  beforeAll(() => {
+    global.logger = { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function mockRes() {
+    return {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+  }
+
+  it('inserts a new Labels row instead of running the LID-keyed UPDATE', async () => {
+    queries.project.sql.mockResolvedValue({ success: true, changes: 1 });
+
+    const req = {
+      body: {
+        selectedLabels: ['newimage.jpg'],
+        selectedClass: 'cat',
+        currentClass: UNLABELED_CLASS,
+        admin: 'testuser',
+        PName: 'test-project',
+      },
+    };
+    const res = mockRes();
+
+    await switchLabels(req, res);
+
+    expect(res.status).not.toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Images assigned to class successfully',
+      labelsAffected: 1,
+    }));
+
+    expect(queries.project.sql).toHaveBeenCalledTimes(1);
+    const [, sql, params] = queries.project.sql.mock.calls[0];
+    expect(sql).toMatch(/^INSERT INTO Labels/);
+    expect(sql).not.toMatch(/UPDATE Labels/);
+    expect(params).toEqual(['cat', 'newimage.jpg']);
+  });
+
+  it('still uses the LID-keyed UPDATE for a normal (non-unlabeled) class switch', async () => {
+    queries.project.sql.mockResolvedValue({ success: true, changes: 1 });
+
+    const req = {
+      body: {
+        selectedLabels: ['42'],
+        selectedClass: 'dog',
+        currentClass: 'cat',
+        admin: 'testuser',
+        PName: 'test-project',
+      },
+    };
+    const res = mockRes();
+
+    await switchLabels(req, res);
+
+    expect(queries.project.sql).toHaveBeenCalledTimes(1);
+    const [, sql] = queries.project.sql.mock.calls[0];
+    expect(sql).toMatch(/^UPDATE Labels/);
+  });
+});

--- a/utils/unlabeledClass.js
+++ b/utils/unlabeledClass.js
@@ -1,0 +1,4 @@
+// Sentinel `class` query-param value used to route the review page (and the
+// switchLabels endpoint) into "unlabeled bucket" mode instead of a real class.
+// Not a row in the Classes table.
+module.exports = "__UNLABELED__";

--- a/views/labeling.ejs
+++ b/views/labeling.ejs
@@ -13,7 +13,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr>
+                        <tr class="unlabeled-row">
                             <!-- Unlabeled bucket: images with zero rows in Labels, not a Classes row -->
                             <td scope="row">
                                 <a href="/review?class=<%= encodeURIComponent(unlabeledClass) %>&IDX=<%= IDX %>">

--- a/views/labeling.ejs
+++ b/views/labeling.ejs
@@ -13,6 +13,15 @@
                         </tr>
                     </thead>
                     <tbody>
+                        <tr>
+                            <!-- Unlabeled bucket: images with zero rows in Labels, not a Classes row -->
+                            <td scope="row">
+                                <a href="/review?class=<%= encodeURIComponent(unlabeledClass) %>&IDX=<%= IDX %>">
+                                    Unlabeled
+                                </a>
+                            </td>
+                            <td class="text-center" style="text-align: center;"><%= unlabeledCount %></td>
+                        </tr>
                         <% for (var i = 0; i < classes.length; i++) { %>
                         <tr>
                             <!-- Class Name as clickable link -->

--- a/views/review.ejs
+++ b/views/review.ejs
@@ -9,10 +9,14 @@
                     <table class="table table-striped">
                         <thead class="thead-dark">
                             <h3 class="justify-content-start">
-                                Review Images for Class: <%= CName %>
+                                Review Images for Class: <%= displayClassName %>
                             </h3>
                             <select class="form-select justify-content-start" aria-label="Default select example"
                                 onchange="window.location.href=this.value;">
+                                <option value="/review?class=<%= encodeURIComponent(unlabeledClass) %>&IDX=<%= IDX %>"
+                                    <%=(selectedClass===unlabeledClass) ? 'selected' : '' %>>
+                                    Unlabeled
+                                </option>
                                 <% classes.forEach(function(classItem) { %>
                                     <option value="/review?class=<%= classItem.CName %>&IDX=<%= IDX %>"
                                         <%=(selectedClass===classItem.CName) ? 'selected' : '' %>>
@@ -41,10 +45,13 @@
                                             </select>
                                         </div>
                                         <div>
-                                            <button id="submitSwitch" type="button" class="btn btn-primary">Switch
-                                                Labels</button>
-                                            <button id="deleteLabels" type="submit" class="btn btn-danger">Delete
-                                                Labels</button>
+                                            <button id="submitSwitch" type="button" class="btn btn-primary">
+                                                <%= isUnlabeledMode ? 'Assign Class' : 'Switch Labels' %>
+                                            </button>
+                                            <% if (!isUnlabeledMode) { %>
+                                                <button id="deleteLabels" type="submit" class="btn btn-danger">Delete
+                                                    Labels</button>
+                                                <% } %>
                                         </div>
                                     </div>
                                 </div>
@@ -59,58 +66,95 @@
             </tr>
             </thead>
             <tbody>
-                <% images.forEach(function(image) { %>
-                    <% let imageName=image.IName; %>
-                        <% let labels=imageLabels[imageName]; %>
-                            <% if (labels) { %>
-                                <% labels.forEach(function(label) { %>
-                                    <% if (label.CName===CName) { %>
-                                        <tr>
-                                            <td>
-                                                <input type="checkbox" 
-                                                    aria-label="<%= label.IName%> label <%= label.LID %>"
-                                                    class="badCheckbox" name="bad_<%= label.LID %>"
-                                                    value="<%= label.LID %>">
-                                            </td>
-                                            <td><a href="/annotate?IDX=<%=IDX%>&IName=<%= label.IName %>" />
-                                                <%= label.IName %>
-                                            </td>
-                                            <td>
-                                                <img class="Image"
-                                                    src="/projects/<%= admin %>-<%= PName %>/images/<%= label.IName %>"
-                                                    aria-label="<%=PName %> <%= label.IName%> label <%= label.LID%>"
-                                                    style="display: none;">
-                                                <input type="hidden" class="LabelX" value="<%= label.X %>">
-                                                <input type="hidden" class="LabelY" value="<%= label.Y %>">
-                                                <input type="hidden" class="LabelWidth" value="<%= label.W %>">
-                                                <input type="hidden" class="LabelHeight" value="<%= label.H %>">
-                                                <canvas id="cropCanvas"
-                                                    style="max-width: 100%; height: 100%; display: block; cursor: pointer;"
-                                                    data-toggle="modal" data-target="#myModal"></canvas>
-                                            </td>
-                                            <td>
-                                                <button type="button" class="btn btn-danger delete-button"
-                                                    data-admin="<%= admin %>" data-pname="<%= PName %>"
-                                                    data-lid="<%= label.LID %>"> Delete</button>
-                                                <form class="SwitchForm" action="/api/switchLabels" method="PUT">
-                                                    <label for="switchClasses_<%= label.LID %>">Switch to:</label>
-                                                    <select name="switchClasses_<%= label.LID %>" class="switchClasses"
-                                                        data-label-id="<%= label.LID %>">
-                                                        <% classes.forEach(function(classItem){ %>
-                                                            <option value="<%= classItem.CName %>">
-                                                                <%= classItem.CName %>
-                                                            </option>
-                                                            <% }); %>
-                                                    </select>
-                                                    <button type="button" class="btn btn-secondary"
-                                                        onclick="handleSwitch(event, '<%= label.LID %>')">Switch</button>
-                                                </form>
-                                            </td>
-                                        </tr>
-                                        <% } %>
+                <% if (isUnlabeledMode) { %>
+                    <% images.forEach(function(image) { %>
+                        <tr>
+                            <td>
+                                <input type="checkbox"
+                                    aria-label="<%= image.IName %> unlabeled"
+                                    class="badCheckbox" name="bad_<%= image.IName %>"
+                                    value="<%= image.IName %>">
+                            </td>
+                            <td><a href="/annotate?IDX=<%=IDX%>&IName=<%= image.IName %>" />
+                                <%= image.IName %>
+                            </td>
+                            <td>
+                                <img class="UnlabeledImage"
+                                    src="/projects/<%= admin %>-<%= PName %>/images/<%= image.IName %>"
+                                    aria-label="<%=PName %> <%= image.IName%>"
+                                    style="max-width: 200px; max-height: 200px;">
+                            </td>
+                            <td>
+                                <form class="SwitchForm" action="/api/switchLabels" method="PUT">
+                                    <label for="switchClasses_<%= image.IName %>">Assign to:</label>
+                                    <select name="switchClasses_<%= image.IName %>" class="switchClasses"
+                                        data-label-id="<%= image.IName %>">
+                                        <% classes.forEach(function(classItem){ %>
+                                            <option value="<%= classItem.CName %>">
+                                                <%= classItem.CName %>
+                                            </option>
                                             <% }); %>
+                                    </select>
+                                    <button type="button" class="btn btn-secondary"
+                                        onclick="handleSwitch(event, '<%= image.IName %>')">Assign</button>
+                                </form>
+                            </td>
+                        </tr>
+                        <% }); %>
+                    <% } else { %>
+                        <% images.forEach(function(image) { %>
+                            <% let imageName=image.IName; %>
+                                <% let labels=imageLabels[imageName]; %>
+                                    <% if (labels) { %>
+                                        <% labels.forEach(function(label) { %>
+                                            <% if (label.CName===CName) { %>
+                                                <tr>
+                                                    <td>
+                                                        <input type="checkbox"
+                                                            aria-label="<%= label.IName%> label <%= label.LID %>"
+                                                            class="badCheckbox" name="bad_<%= label.LID %>"
+                                                            value="<%= label.LID %>">
+                                                    </td>
+                                                    <td><a href="/annotate?IDX=<%=IDX%>&IName=<%= label.IName %>" />
+                                                        <%= label.IName %>
+                                                    </td>
+                                                    <td>
+                                                        <img class="Image"
+                                                            src="/projects/<%= admin %>-<%= PName %>/images/<%= label.IName %>"
+                                                            aria-label="<%=PName %> <%= label.IName%> label <%= label.LID%>"
+                                                            style="display: none;">
+                                                        <input type="hidden" class="LabelX" value="<%= label.X %>">
+                                                        <input type="hidden" class="LabelY" value="<%= label.Y %>">
+                                                        <input type="hidden" class="LabelWidth" value="<%= label.W %>">
+                                                        <input type="hidden" class="LabelHeight" value="<%= label.H %>">
+                                                        <canvas id="cropCanvas"
+                                                            style="max-width: 100%; height: 100%; display: block; cursor: pointer;"
+                                                            data-toggle="modal" data-target="#myModal"></canvas>
+                                                    </td>
+                                                    <td>
+                                                        <button type="button" class="btn btn-danger delete-button"
+                                                            data-admin="<%= admin %>" data-pname="<%= PName %>"
+                                                            data-lid="<%= label.LID %>"> Delete</button>
+                                                        <form class="SwitchForm" action="/api/switchLabels" method="PUT">
+                                                            <label for="switchClasses_<%= label.LID %>">Switch to:</label>
+                                                            <select name="switchClasses_<%= label.LID %>" class="switchClasses"
+                                                                data-label-id="<%= label.LID %>">
+                                                                <% classes.forEach(function(classItem){ %>
+                                                                    <option value="<%= classItem.CName %>">
+                                                                        <%= classItem.CName %>
+                                                                    </option>
+                                                                    <% }); %>
+                                                            </select>
+                                                            <button type="button" class="btn btn-secondary"
+                                                                onclick="handleSwitch(event, '<%= label.LID %>')">Switch</button>
+                                                        </form>
+                                                    </td>
+                                                </tr>
                                                 <% } %>
                                                     <% }); %>
+                                                        <% } %>
+                                                            <% }); %>
+                                                                <% } %>
             </tbody>
             </table>
         </div>
@@ -261,7 +305,7 @@
             }
         });
 
-        document.getElementById("deleteLabels").addEventListener("click", async function () {
+        document.getElementById("deleteLabels")?.addEventListener("click", async function () {
             event.preventDefault();
 
             let selectedLabels = [];


### PR DESCRIPTION
## Summary
- Labeling page (`getLabelingPage.js` + `labeling.ejs`) now shows an "Unlabeled" row, separate from the Classes loop, with a count of images that have zero rows in `Labels`.
- Review page (`getReviewPage.js` + `review.ejs`) gains a distinct mode (triggered by a sentinel `class` query value, `utils/unlabeledClass.js`) that selects `Images` with no matching `Labels` row instead of the `INNER JOIN Labels WHERE Labels.CName = ?` path, reusing the same checkbox/switch-class UI (checkboxes keyed by image name instead of LID, no crop overlay since there's no bounding box yet, no per-row/bulk delete button since there's no label to delete).
- `switchLabels.js` now branches: assigning a class to a previously-unlabeled image INSERTs a new `Labels` row keyed by image name (full-image box, X=Y=0, W=H=0) instead of the LID-keyed `UPDATE`, since unlabeled images have no existing `Labels` row.

Based on `agent/njobvu-feature-architect/6eb35dfe` per scoping from njobvu-feature-architect on CEO-24.

## Test plan
- [x] `npx jest tests/integration/unlabeledLabelingPage.test.js tests/integration/unlabeledReviewPage.test.js tests/integration/unlabeledSwitchLabels.test.js` - all pass (bucket count, review-page redirect target, and class-assignment INSERT path, plus a regression check that normal class switches still UPDATE)
- [x] Confirmed pre-existing test suites (`labelingPage.test.js`, `updateLabels.test.js`, etc.) fail identically on `dec3a95` before this change too (unrelated `node-fetch@3` ESM/Jest issue) - no new regressions introduced