### PR TITLE
feat: add project class list download option

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -75,6 +75,7 @@ const downloadProject = require("./downloads/downloadProject");
 const downloadScript = require("./downloads/downloadScript");
 const downloadWeights = require("./downloads/downloadWeights");
 const downloadRun = require("./downloads/downloadRun");
+const downloadClasses = require("./downloads/downloadClasses");
 
 const test = require("./tests/test");
 const mergeTest = require("./tests/mergeTest");
@@ -182,6 +183,7 @@ api.post("/downloadProject", downloadProject);
 api.post("/downloadScript", downloadScript);
 api.post("/downloadWeights", downloadWeights);
 api.post("/downloadRun", downloadRun);
+api.post("/downloadClasses", downloadClasses);
 
 // VALIDATION ROUTES
 api.post("/changeValidation", changeValidation);

--- a/routes/downloads/downloadClasses.js
+++ b/routes/downloads/downloadClasses.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const queries = require("../../queries/queries");
+
+async function downloadClasses(req, res) {
+    var PName = req.body.PName;
+    var admin = req.body.Admin;
+    var username = req.cookies.Username;
+
+    var publicPath = currentPath,
+        mainPath = publicPath + "public/projects/",
+        projectPath = mainPath + admin + "-" + PName,
+        downloadPath = mainPath + username + "_Downloads";
+
+    if (!fs.existsSync(downloadPath)) {
+        fs.mkdirSync(downloadPath);
+    }
+
+    let existingClasses;
+    try {
+        existingClasses = await queries.project.getAllClasses(projectPath);
+    } catch (err) {
+        global.logger.error(err);
+        return res
+            .status(500)
+            .json({ success: false, message: "Error fetching classes" });
+    }
+
+    if (!existingClasses.rows.length) {
+        return res.json({
+            success: false,
+            message: "No classes found for this project",
+        });
+    }
+
+    var classList =
+        existingClasses.rows.map((row) => row.CName).join("\n") + "\n";
+    var classListFile = `${PName}_ClassList.txt`;
+    var classListPath = `${downloadPath}/${classListFile}`;
+
+    try {
+        fs.writeFileSync(classListPath, classList);
+    } catch (err) {
+        global.logger.error(err);
+        return res
+            .status(500)
+            .json({ success: false, message: "Error writing class list" });
+    }
+
+    return res.download(classListPath);
+}
+
+module.exports = downloadClasses;

--- a/tests/integration/download.test.js
+++ b/tests/integration/download.test.js
@@ -9,6 +9,9 @@ jest.mock('unzipper', () => jest.fn());
 jest.mock('child_process', () => ({
   exec: jest.fn(),
 }));
+// node-fetch@3 is ESM-only, which Jest in this repo isn't configured to transform;
+// requiring app.js pulls it in via routes/chat/ollamaChat.js.
+jest.mock('node-fetch', () => jest.fn());
 jest.mock('sqlite3', () => {
   const mock = {
     OPEN_CREATE: 1,
@@ -152,5 +155,90 @@ describe('Download Dataset Route', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.text).toContain('downloaded:');
+  });
+});
+
+describe('Download Classes Route', () => {
+  beforeAll(() => {
+    global.db = {
+      runAsync: jest.fn().mockResolvedValue(undefined),
+      allAsync: jest.fn().mockResolvedValue([]),
+      getAsync: jest.fn().mockResolvedValue({ row: { THING: 0 } }),
+    };
+    global.currentPath = '/test/path/';
+    global.projectDbClients = {};
+    global.logger = { error: jest.fn(), debug: jest.fn(), info: jest.fn() };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should successfully download the project class list as a text file', async () => {
+    const res = await request(app)
+      .post('/downloadClasses')
+      .send({
+        PName: 'test-project',
+        Admin: 'testuser',
+        IDX: 1,
+      })
+      .set('Cookie', ['Username=testuser']);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.text).toContain('downloaded:');
+    expect(res.text).toContain('test-project_ClassList.txt');
+
+    const queries = require('../../queries/queries');
+    expect(queries.project.getAllClasses).toHaveBeenCalledWith(
+      '/test/path/public/projects/testuser-test-project',
+    );
+
+    const fs = require('fs');
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      '/test/path/public/projects/testuser_Downloads/test-project_ClassList.txt',
+      'class1\nclass2\n',
+    );
+  });
+
+  it('should return a JSON error when the project has no classes', async () => {
+    const queries = require('../../queries/queries');
+    queries.project.getAllClasses.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post('/downloadClasses')
+      .send({
+        PName: 'empty-project',
+        Admin: 'testuser',
+        IDX: 1,
+      })
+      .set('Cookie', ['Username=testuser']);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/json/);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'No classes found for this project',
+    });
+  });
+
+  it('should return a 500 JSON error when fetching classes fails', async () => {
+    const queries = require('../../queries/queries');
+    queries.project.getAllClasses.mockRejectedValueOnce(new Error('db error'));
+
+    const res = await request(app)
+      .post('/downloadClasses')
+      .send({
+        PName: 'broken-project',
+        Admin: 'testuser',
+        IDX: 1,
+      })
+      .set('Cookie', ['Username=testuser']);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.headers['content-type']).toMatch(/json/);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Error fetching classes',
+    });
   });
 });

--- a/views/download.ejs
+++ b/views/download.ejs
@@ -33,6 +33,21 @@
 		<div class="col-md-12">
 			<div class="card">
 				<div class="card-header">
+					Download Class List
+				</div>
+				<div class="card-body">
+					<form class="download-classes-form" action ="/downloadClasses" method="POST" enctype="multipart/form-data" id="downloadClassesForm" style="text-align: center;">
+						<input id = "ClassesPName" type="hidden" name="PName" value="<%= PName %>">
+						<input id = "ClassesAdmin" type="hidden" name="Admin" value="<%= Admin %>">
+						<input id = "ClassesIDX" type="hidden" name="IDX" value="<%= IDX %>">
+						<button id = "downloadclassesbtn" name="form_action" value="download" class="btn btn-primary" style="text-align: center;">Download Class List</button>
+					</form>
+				</div>
+			</div>
+		</div>
+		<div class="col-md-12">
+			<div class="card">
+				<div class="card-header">
 					Download Dataset
 				</div>
 				<div class="card-body">


### PR DESCRIPTION
## Summary
- Adds a "Download Class List" card to the project download page that exports a project's class names as a plain-text file (`<PName>_ClassList.txt`)
- New route handler `routes/downloads/downloadClasses.js` reuses the existing `queries.project.getAllClasses` query, following the same pattern as the other `routes/downloads/*` handlers
- Registered `POST /downloadClasses` in `routes/api.js`

## Test plan
- [x] `npx jest tests/integration/download.test.js` — new success/empty-list/db-error cases pass alongside existing dataset tests
- [ ] Manual UI check of the new "Download Class List" card on the project download page

Closes CEO-25.