### PR TITLE
feat: add per-class image counts and minimum-images clamp to YOLO training settings

### DIFF
--- a/queries/classes/classes.js
+++ b/queries/classes/classes.js
@@ -17,6 +17,13 @@ module.exports = {
 
             return result;
         },
+        getClassImageCounts: async function (projectPath) {
+            const db = getDbClient(projectPath);
+            const query = "SELECT CName, COUNT(DISTINCT IName) as imageCount FROM Labels GROUP BY CName";
+            const result = await db.all(query);
+
+            return result;
+        },
         createClass: async function (projectPath, value) {
             const db = getDbClient(projectPath);
             const query = "INSERT INTO Classes (CName) VALUES (?)";

--- a/routes/pages/getYoloXTrainingSettingsPage.js
+++ b/routes/pages/getYoloXTrainingSettingsPage.js
@@ -1,3 +1,5 @@
+const queries = require("../../queries/queries");
+
 async function getYoloXInferencePage(req, res) {
     global.logger.debug("get yolo (ultralytics) X training Setting Page");
     const readdir = util.promisify(fs.readdir);
@@ -140,6 +142,25 @@ async function getYoloXInferencePage(req, res) {
         "'",
     );
     var results2 = await tdb.allAsync("SELECT * FROM `Classes`");
+
+    // Attach per-class image counts so the training page can show them next to each checkbox
+    // and clamp selection to classes with enough images.
+    var classImageCounts = {};
+    try {
+        var countsResult = await queries.project.getClassImageCounts(project_path);
+        if (countsResult && countsResult.rows) {
+            countsResult.rows.forEach(function (row) {
+                classImageCounts[row.CName] = row.imageCount;
+            });
+        }
+    } catch (err) {
+        global.logger.error(err);
+    }
+    results2 = results2.map(function (cls) {
+        return Object.assign({}, cls, {
+            imageCount: classImageCounts[cls.CName] || 0,
+        });
+    });
 
     var acc = await db.allAsync(
         "SELECT * FROM `Access` WHERE PName = '" +

--- a/tests/integration/classImageCounts.test.js
+++ b/tests/integration/classImageCounts.test.js
@@ -1,0 +1,45 @@
+// Unit tests for queries/classes/classes.js#getClassImageCounts, the query backing the
+// per-class image count label and "Minimum Images per Class" clamp on the YOLO training
+// settings page.
+
+jest.mock('../../queries/getDbClient');
+
+const getDbClient = require('../../queries/getDbClient');
+const classes = require('../../queries/classes/classes');
+
+describe('queries/classes getClassImageCounts', () => {
+  let mockAll;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAll = jest.fn();
+    getDbClient.mockReturnValue({ all: mockAll });
+  });
+
+  it('runs a GROUP BY CName query over Labels and returns the raw db.all() result', async () => {
+    const dbResult = {
+      success: true,
+      rows: [
+        { CName: 'person', imageCount: 12 },
+        { CName: 'car', imageCount: 0 },
+      ],
+    };
+    mockAll.mockResolvedValue(dbResult);
+
+    const result = await classes.project.getClassImageCounts('/projects/testuser-test-project');
+
+    expect(getDbClient).toHaveBeenCalledWith('/projects/testuser-test-project');
+    expect(mockAll).toHaveBeenCalledWith(
+      'SELECT CName, COUNT(DISTINCT IName) as imageCount FROM Labels GROUP BY CName',
+    );
+    expect(result).toBe(dbResult);
+  });
+
+  it('propagates errors from the underlying db client', async () => {
+    mockAll.mockRejectedValue(new Error('db unavailable'));
+
+    await expect(
+      classes.project.getClassImageCounts('/projects/testuser-test-project'),
+    ).rejects.toThrow('db unavailable');
+  });
+});

--- a/tests/integration/yoloTrainingClassClamp.test.js
+++ b/tests/integration/yoloTrainingClassClamp.test.js
@@ -1,0 +1,125 @@
+// Exercises the actual "Minimum Images per Class" clamp script shipped inline in
+// views/training/yolovXTrainingSettings.ejs. No jsdom dependency is available in this repo, so this
+// extracts the real <script> block verbatim and runs it against a minimal fake `document`, driving
+// it exactly like a browser would (getElementById/querySelectorAll/addEventListener + stored
+// listener callbacks). This is the only place the auto-deselect-below-threshold behavior, and its
+// re-application on Select All, is verified end to end.
+
+const fs = require('fs');
+const path = require('path');
+
+function extractClassSelectionScript() {
+  const templatePath = path.join(__dirname, '../../views/training/yolovXTrainingSettings.ejs');
+  const template = fs.readFileSync(templatePath, 'utf8');
+
+  const startMarker = '// Class selection helper buttons';
+  const endMarker = '// Split ratio summary update';
+  const start = template.indexOf(startMarker);
+  const end = template.indexOf(endMarker);
+
+  if (start === -1 || end === -1) {
+    throw new Error('Could not locate class selection script block in template');
+  }
+
+  return template.slice(start, end);
+}
+
+function makeCheckbox(count, checked) {
+  return {
+    checked,
+    getAttribute: jest.fn(() => String(count)),
+  };
+}
+
+function makeFakeDocument(checkboxes) {
+  const elements = {};
+  const listeners = {};
+
+  function makeButtonLike(id) {
+    const el = {
+      addEventListener: jest.fn((evt, handler) => {
+        listeners[id] = listeners[id] || {};
+        listeners[id][evt] = handler;
+      }),
+    };
+    elements[id] = el;
+    return el;
+  }
+
+  makeButtonLike('selectAllClasses');
+  makeButtonLike('deselectAllClasses');
+
+  const minInput = makeButtonLike('minClassImages');
+  minInput.value = '';
+
+  const doc = {
+    getElementById: jest.fn((id) => elements[id]),
+    querySelectorAll: jest.fn((selector) => {
+      if (selector === '.class-checkbox') {
+        return {
+          forEach: (fn) => checkboxes.forEach(fn),
+        };
+      }
+      return { forEach: () => {} };
+    }),
+  };
+
+  return { doc, listeners, minInput };
+}
+
+describe('yolovXTrainingSettings.ejs class selection + minimum images clamp script', () => {
+  let checkboxes;
+  let doc;
+  let listeners;
+  let minInput;
+
+  beforeEach(() => {
+    // Mirrors data-image-count rendered per checkbox: person=10, car=3, dog=0
+    checkboxes = [
+      makeCheckbox(10, true),
+      makeCheckbox(3, true),
+      makeCheckbox(0, true),
+    ];
+    ({ doc, listeners, minInput } = makeFakeDocument(checkboxes));
+
+    const script = extractClassSelectionScript();
+    // eslint-disable-next-line no-new-func
+    const run = new Function('document', script);
+    run(doc);
+  });
+
+  it('does nothing when the minimum images threshold is empty/zero', () => {
+    minInput.value = '';
+    listeners.minClassImages.input();
+
+    expect(checkboxes.map((cb) => cb.checked)).toEqual([true, true, true]);
+  });
+
+  it('unchecks only classes below the configured minimum on input', () => {
+    minInput.value = '5';
+    listeners.minClassImages.input();
+
+    expect(checkboxes.map((cb) => cb.checked)).toEqual([true, false, false]);
+  });
+
+  it('re-applies the clamp when Select All is clicked, so it cannot bypass the minimum', () => {
+    minInput.value = '5';
+    listeners.minClassImages.input();
+    expect(checkboxes.map((cb) => cb.checked)).toEqual([true, false, false]);
+
+    listeners.selectAllClasses.click();
+
+    // Select All checks everything first, then the clamp must immediately re-uncheck
+    // the classes that don't meet the threshold.
+    expect(checkboxes.map((cb) => cb.checked)).toEqual([true, false, false]);
+  });
+
+  it('Deselect All unchecks everything regardless of the clamp threshold', () => {
+    minInput.value = '5';
+    listeners.minClassImages.input();
+
+    listeners.deselectAllClasses.click();
+
+    expect(checkboxes.map((cb) => cb.checked)).toEqual([false, false, false]);
+  });
+});

--- a/tests/integration/yoloXTrainingSettingsClassCounts.test.js
+++ b/tests/integration/yoloXTrainingSettingsClassCounts.test.js
@@ -1,0 +1,145 @@
+// Integration tests for GET /yolo/yolovXTrainingSettings's per-class image count wiring
+// (routes/pages/getYoloXTrainingSettingsPage.js). Invokes the route handler directly, bypassing
+// the Express/static stack, matching the convention already used for this route family in
+// tests/integration/trainingPage.test.js -- this codebase drives page routes entirely through
+// globals set by server.js rather than importable modules.
+
+jest.mock('../../queries/queries', () => ({
+  project: {
+    getClassImageCounts: jest.fn(),
+  },
+}));
+
+const queries = require('../../queries/queries');
+
+const PROJECT_PATH = '/test/path/public/projects/testuser-test-project';
+const LOG_PATH = `${PROJECT_PATH}/training/logs/`;
+const WEIGHTS_PATH = `${PROJECT_PATH}/training/weights`;
+const PYTHON_PATH = `${PROJECT_PATH}/training/python`;
+const INFERENCE_PATH = `${PROJECT_PATH}/inference`;
+const INFERENCE_UPLOAD_PATH = `${PROJECT_PATH}/inference/uploads`;
+
+describe('GET /yolo/yolovXTrainingSettings - per-class image counts', () => {
+  let getYoloXTrainingSettingsPage;
+
+  beforeAll(() => {
+    global.logger = { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    global.util = require('util');
+    global.currentPath = '/test/path/';
+    global.configFile = { default_yolo_path: '' };
+
+    global.db = {
+      allAsync: jest.fn().mockResolvedValue([
+        { PName: 'test-project', Admin: 'testuser', Username: 'testuser' },
+      ]),
+      getAsync: jest.fn().mockResolvedValue({
+        PDescription: 'Test project description',
+        PName: 'test-project',
+        Admin: 'testuser',
+        AutoSave: 1,
+      }),
+    };
+
+    global.sqlite3 = {
+      Database: jest.fn((dbPath, cb) => {
+        if (typeof cb === 'function') cb(null);
+        return {
+          get: jest.fn((sql, cb2) => cb2 && cb2(null, {})),
+          all: jest.fn((sql, cb2) =>
+            cb2 && cb2(null, [
+              { CName: 'person' },
+              { CName: 'car' },
+              { CName: 'unlabeled_class' },
+            ]),
+          ),
+          close: jest.fn((cb2) => cb2 && cb2()),
+        };
+      }),
+    };
+
+    global.fs = {
+      existsSync: jest.fn().mockReturnValue(true),
+      mkdirSync: jest.fn(),
+      writeFile: jest.fn((p, data, cb) => cb && cb(null)),
+      readFileSync: jest.fn().mockReturnValue(''),
+      readdir: jest.fn((p, cb) => cb(null, [])),
+      readFile: jest.fn((p, enc, cb) => (cb || enc)(null, '')),
+      statSync: jest.fn(() => ({ isDirectory: () => false, isFile: () => true })),
+    };
+
+    global.readdirAsync = jest.fn((dirPath) => {
+      if ([LOG_PATH, WEIGHTS_PATH, PYTHON_PATH, INFERENCE_PATH, INFERENCE_UPLOAD_PATH].includes(dirPath)) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    });
+
+    getYoloXTrainingSettingsPage = require('../../routes/pages/getYoloXTrainingSettingsPage');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    global.db.allAsync.mockResolvedValue([
+      { PName: 'test-project', Admin: 'testuser', Username: 'testuser' },
+    ]);
+    global.db.getAsync.mockResolvedValue({
+      PDescription: 'Test project description',
+      PName: 'test-project',
+      Admin: 'testuser',
+      AutoSave: 1,
+    });
+  });
+
+  function makeReqRes() {
+    const req = { query: { IDX: '0' }, cookies: { Username: 'testuser' } };
+    const res = { render: jest.fn(), redirect: jest.fn() };
+    return { req, res };
+  }
+
+  it('attaches imageCount to each class from queries.project.getClassImageCounts, keyed by CName', async () => {
+    queries.project.getClassImageCounts.mockResolvedValue({
+      success: true,
+      rows: [
+        { CName: 'person', imageCount: 42 },
+        { CName: 'car', imageCount: 7 },
+        // no row for 'unlabeled_class' -- must default to 0, not be dropped or crash
+      ],
+    });
+
+    const { req, res } = makeReqRes();
+    await expect(getYoloXTrainingSettingsPage(req, res)).resolves.not.toThrow();
+
+    expect(queries.project.getClassImageCounts).toHaveBeenCalledWith(
+      expect.stringContaining('testuser-test-project'),
+    );
+    expect(res.render).toHaveBeenCalledWith(
+      'training/yolovXTrainingSettings',
+      expect.objectContaining({
+        classes: [
+          expect.objectContaining({ CName: 'person', imageCount: 42 }),
+          expect.objectContaining({ CName: 'car', imageCount: 7 }),
+          expect.objectContaining({ CName: 'unlabeled_class', imageCount: 0 }),
+        ],
+      }),
+    );
+  });
+
+  it('defaults every class to imageCount 0 and still renders when the count query fails', async () => {
+    queries.project.getClassImageCounts.mockRejectedValue(new Error('db unavailable'));
+
+    const { req, res } = makeReqRes();
+    await expect(getYoloXTrainingSettingsPage(req, res)).resolves.not.toThrow();
+
+    expect(res.render).toHaveBeenCalledWith(
+      'training/yolovXTrainingSettings',
+      expect.objectContaining({
+        classes: [
+          expect.objectContaining({ CName: 'person', imageCount: 0 }),
+          expect.objectContaining({ CName: 'car', imageCount: 0 }),
+          expect.objectContaining({ CName: 'unlabeled_class', imageCount: 0 }),
+        ],
+      }),
+    );
+    expect(global.logger.error).toHaveBeenCalled();
+  });
+});

--- a/views/training/yolovXTrainingSettings.ejs
+++ b/views/training/yolovXTrainingSettings.ejs
@@ -162,13 +162,17 @@
 											<div class="mb-2">
 												<button type="button" class="btn btn-sm btn-outline-primary" id="selectAllClasses">Select All</button>
 												<button type="button" class="btn btn-sm btn-outline-secondary" id="deselectAllClasses">Deselect All</button>
+												<span class="d-inline-block ml-3">
+													<label for="minClassImages" class="mr-1 mb-0">Minimum Images per Class:</label>
+													<input type="number" id="minClassImages" name="min_class_images" min="0" placeholder="0" class="form-control form-control-sm d-inline-block" style="width: 100px;">
+												</span>
 											</div>
 											<div class="class-selection-container" style="max-height: 150px; overflow-y: auto;">
 												<% if (typeof classes !== 'undefined' && classes.length > 0) { %>
 													<% for (var i = 0; i < classes.length; i++) { %>
 														<div class="form-check form-check-inline mr-3 my-1">
-															<input class="form-check-input class-checkbox" type="checkbox" name="selected_classes" id="class_<%= i %>" value="<%= classes[i].CName %>" checked>
-															<label class="form-check-label" for="class_<%= i %>"><%= classes[i].CName %></label>
+															<input class="form-check-input class-checkbox" type="checkbox" name="selected_classes" id="class_<%= i %>" value="<%= classes[i].CName %>" data-image-count="<%= classes[i].imageCount || 0 %>" checked>
+															<label class="form-check-label" for="class_<%= i %>"><%= classes[i].CName %> <span class="text-muted small">(<%= classes[i].imageCount || 0 %> images)</span></label>
 														</div>
 													<% } %>
 												<% } else { %>
@@ -325,15 +329,36 @@
 					// Class selection helper buttons
 					var selectAllBtn = document.getElementById("selectAllClasses");
 					var deselectAllBtn = document.getElementById("deselectAllClasses");
+					var minClassImagesInput = document.getElementById("minClassImages");
+
+					// Unchecks any class checkbox whose image count is below the configured minimum,
+					// so Select All (or manually re-checking a box) can't bypass the clamp.
+					function applyMinClassImagesClamp() {
+						var threshold = parseInt(minClassImagesInput && minClassImagesInput.value, 10) || 0;
+						if (threshold <= 0) {
+							return;
+						}
+						document.querySelectorAll(".class-checkbox").forEach(function(cb) {
+							var count = parseInt(cb.getAttribute("data-image-count"), 10) || 0;
+							if (count < threshold) {
+								cb.checked = false;
+							}
+						});
+					}
+
 					if (selectAllBtn) {
 						selectAllBtn.addEventListener("click", function() {
 							document.querySelectorAll(".class-checkbox").forEach(function(cb) { cb.checked = true; });
+							applyMinClassImagesClamp();
 						});
 					}
 					if (deselectAllBtn) {
 						deselectAllBtn.addEventListener("click", function() {
 							document.querySelectorAll(".class-checkbox").forEach(function(cb) { cb.checked = false; });
 						});
+					}
+					if (minClassImagesInput) {
+						minClassImagesInput.addEventListener("input", applyMinClassImagesClamp);
 					}
 
 					// Split ratio summary update


### PR DESCRIPTION
## Summary
- Adds `getClassImageCounts` to `queries/classes/classes.js` (`SELECT CName, COUNT(DISTINCT IName) as imageCount FROM Labels GROUP BY CName`), following the existing `getAllClasses` pattern.
- Wires it into `routes/pages/getYoloXTrainingSettingsPage.js` and attaches `imageCount` to each class passed to the view (defaults to 0 on missing rows or a query failure).
- Renders the count next to each class checkbox in `views/training/yolovXTrainingSettings.ejs`.
- Adds a "Minimum Images per Class" number input (next to Select All/Deselect All) that unchecks any class checkbox below the threshold client-side, and re-applies on Select All so the clamp can't be bypassed.

## Test plan
- [x] `queries/classes/classes.js#getClassImageCounts` unit-tested (query shape, error propagation)
- [x] Route-level test verifying counts are attached per class and default to 0 (including when the count query fails)
- [x] Script-level test exercising the actual shipped clamp logic (input, Select All re-clamp, Deselect All)
- [x] `npx jest` run clean for all new/touched suites (pre-existing unrelated suite failures in this repo are due to a missing `config.json` and an un-mocked ESM `node-fetch` import in a few other test files — unrelated to this change)