### PR TITLE
feat: log run options at start of training/inference logs; filter coco-classes from inference listings

### DIFF
--- a/routes/inference/inceptionInference.js
+++ b/routes/inference/inceptionInference.js
@@ -1,5 +1,6 @@
 const queries = require("../../queries/queries");
 const { exec } = require("child_process");
+const formatRunOptionsHeader = require("../../utils/formatRunOptionsHeader");
 
 async function inceptionInference(req, res) {
     try {
@@ -67,7 +68,17 @@ async function inceptionInference(req, res) {
         let success = "";
         let error = "";
 
-        fs.writeFileSync(`${runPath}/${log}`, `${cmd}\n\n`);
+        const runOptionsHeader = formatRunOptionsHeader({
+            project: PName,
+            inference_file: inferenceFile,
+            device,
+            options,
+            weights: weightName,
+            top_k: topK,
+            using_imagenet_classes: usingImageNetClasses,
+        });
+
+        fs.writeFileSync(`${runPath}/${log}`, `${runOptionsHeader}${cmd}\n\n`);
 
         exec(cmd, (err, stdout, stderr) => {
             if (err) {

--- a/routes/inference/yoloInference.js
+++ b/routes/inference/yoloInference.js
@@ -1,5 +1,6 @@
 const queries = require("../../queries/queries");
 const path = require("path");
+const formatRunOptionsHeader = require("../../utils/formatRunOptionsHeader");
 
 async function yoloInference(req, res) {
     try {
@@ -159,7 +160,17 @@ async function yoloInference(req, res) {
         var success = "";
         var error = "";
 
-        fs.writeFileSync(`${absUltralyticsProjectRun}/${log}`, `${cmd}\n\n`);
+        const runOptionsHeader = formatRunOptionsHeader({
+            project: PName,
+            task: yoloTask,
+            yolovx_path: yolovxPath,
+            inference_file: inferenceFile,
+            device,
+            options,
+            weights: weightName,
+        });
+
+        fs.writeFileSync(`${absUltralyticsProjectRun}/${log}`, `${runOptionsHeader}${cmd}\n\n`);
 
         exec(cmd, (err, stdout, stderr) => {
             if (err) {

--- a/routes/pages/getInferencePage.js
+++ b/routes/pages/getInferencePage.js
@@ -1,5 +1,6 @@
 const fsPath = require("path");
 const fs = require("fs");
+const { isReservedInferenceFile } = require("../../utils/isRunArtifactFile");
 
 async function getProcessingPage(req, res) {
     const readdir = util.promisify(fs.readdir);
@@ -390,10 +391,7 @@ async function getProcessingPage(req, res) {
                 if (j == err_idx_inf) {
                     continue;
                 }
-                if (
-                    `${logs_inf[j]}` == "datatovalues.py" ||
-                    `${logs_inf[j]}` == "output"
-                ) {
+                if (isReservedInferenceFile(`${logs_inf[j]}`)) {
                     continue;
                 }
                 // weight_inf.push(`${run_path_inf}${logs_inf[j]}`);
@@ -410,10 +408,7 @@ async function getProcessingPage(req, res) {
                 if (j == done_idx_inf) {
                     continue;
                 }
-                if (
-                    `${logs_inf[j]}` == "datatovalues.py" ||
-                    `${logs_inf[j]}` == "output"
-                ) {
+                if (isReservedInferenceFile(`${logs_inf[j]}`)) {
                     continue;
                 }
                 // weight_inf.push(`${run_path_inf}${logs_inf[j]}`);
@@ -431,10 +426,7 @@ async function getProcessingPage(req, res) {
                 // {
                 // 	continue;
                 // }
-                if (
-                    `${logs_inf[j]}` == "datatovalues.py" ||
-                    `${logs_inf[j]}` == "output"
-                ) {
+                if (isReservedInferenceFile(`${logs_inf[j]}`)) {
                     continue;
                 }
                 // weight_inf.push(`${run_path_inf}${logs_inf[j]}`);

--- a/routes/pages/getProcessingPage.js
+++ b/routes/pages/getProcessingPage.js
@@ -1,3 +1,5 @@
+const { isReservedInferenceFile } = require("../../utils/isRunArtifactFile");
+
 async function getProcessingPage(req, res) {
     const readdir = util.promisify(fs.readdir);
     const readFile = util.promisify(fs.readFile);
@@ -333,10 +335,7 @@ async function getProcessingPage(req, res) {
                 if (j == err_idx_inf) {
                     continue;
                 }
-                if (
-                    `${logs_inf[j]}` == "datatovalues.py" ||
-                    `${logs_inf[j]}` == "output"
-                ) {
+                if (isReservedInferenceFile(`${logs_inf[j]}`)) {
                     continue;
                 }
                 // weight_inf.push(`${run_path_inf}${logs_inf[j]}`);
@@ -353,10 +352,7 @@ async function getProcessingPage(req, res) {
                 if (j == done_idx_inf) {
                     continue;
                 }
-                if (
-                    `${logs_inf[j]}` == "datatovalues.py" ||
-                    `${logs_inf[j]}` == "output"
-                ) {
+                if (isReservedInferenceFile(`${logs_inf[j]}`)) {
                     continue;
                 }
                 // weight_inf.push(`${run_path_inf}${logs_inf[j]}`);
@@ -375,10 +371,7 @@ async function getProcessingPage(req, res) {
                 // {
                 // 	continue;
                 // }
-                if (
-                    `${logs_inf[j]}` == "datatovalues.py" ||
-                    `${logs_inf[j]}` == "output"
-                ) {
+                if (isReservedInferenceFile(`${logs_inf[j]}`)) {
                     continue;
                 }
                 // weight_inf.push(`${run_path_inf}${logs_inf[j]}`);

--- a/routes/pages/getTrainingPage.js
+++ b/routes/pages/getTrainingPage.js
@@ -1,3 +1,5 @@
+const { isReservedInferenceFile } = require("../../utils/isRunArtifactFile");
+
 async function getProcessingPage(req, res) {
     const readdir = util.promisify(fs.readdir);
     const readFile = util.promisify(fs.readFile);
@@ -333,10 +335,7 @@ async function getProcessingPage(req, res) {
                 if (j == err_idx_inf) {
                     continue;
                 }
-                if (
-                    `${logs_inf[j]}` == "datatovalues.py" ||
-                    `${logs_inf[j]}` == "output"
-                ) {
+                if (isReservedInferenceFile(`${logs_inf[j]}`)) {
                     continue;
                 }
                 // weight_inf.push(`${run_path_inf}${logs_inf[j]}`);
@@ -353,10 +352,7 @@ async function getProcessingPage(req, res) {
                 if (j == done_idx_inf) {
                     continue;
                 }
-                if (
-                    `${logs_inf[j]}` == "datatovalues.py" ||
-                    `${logs_inf[j]}` == "output"
-                ) {
+                if (isReservedInferenceFile(`${logs_inf[j]}`)) {
                     continue;
                 }
                 // weight_inf.push(`${run_path_inf}${logs_inf[j]}`);
@@ -375,10 +371,7 @@ async function getProcessingPage(req, res) {
                 // {
                 // 	continue;
                 // }
-                if (
-                    `${logs_inf[j]}` == "datatovalues.py" ||
-                    `${logs_inf[j]}` == "output"
-                ) {
+                if (isReservedInferenceFile(`${logs_inf[j]}`)) {
                     continue;
                 }
                 // weight_inf.push(`${run_path_inf}${logs_inf[j]}`);

--- a/routes/training/run.js
+++ b/routes/training/run.js
@@ -1,4 +1,5 @@
 const queries = require("../../queries/queries");
+const formatRunOptionsHeader = require("../../utils/formatRunOptionsHeader");
 
 async function run(req, res) {
     const { exec } = require("child_process");
@@ -45,7 +46,16 @@ async function run(req, res) {
         fs.mkdirSync(runPath);
     }
 
-    fs.writeFile(`${runPath}/${log}`, "", (err) => {
+    const runOptionsHeader = formatRunOptionsHeader({
+        project: PName,
+        python_path: pythonPath,
+        script,
+        training_percent: TrainingPercent,
+        weights,
+        options,
+    });
+
+    fs.writeFile(`${runPath}/${log}`, runOptionsHeader, (err) => {
         if (err) throw err;
     });
 

--- a/routes/training/yoloRun.js
+++ b/routes/training/yoloRun.js
@@ -5,6 +5,7 @@ const fs = require("fs");
 const probe = require("probe-image-size");
 const os = require("os");
 const sharp = require("sharp");
+const formatRunOptionsHeader = require("../../utils/formatRunOptionsHeader");
 
 // Function to detect the best available device for YOLO training
 async function detectBestDevice() {
@@ -870,7 +871,25 @@ async function yoloRun(req, res) {
 
     global.logger.debug("=== STARTING PYTHON SCRIPT ===");
 
-    fs.writeFileSync(`${absDarknetProjectRun}/${log}`, cmd);
+    const runOptionsHeader = formatRunOptionsHeader({
+        project: PName,
+        task: yoloTask,
+        mode: yoloMode,
+        yolo_version: yoloVersion,
+        yolovx_path: yolovxPath,
+        training_percent: trainDataPer,
+        batch,
+        subdiv,
+        width,
+        height,
+        epochs,
+        imgsz,
+        device: requestedDevice,
+        options,
+        weights: weightName,
+    });
+
+    fs.writeFileSync(`${absDarknetProjectRun}/${log}`, `${runOptionsHeader}${cmd}`);
 
     exec(cmd, { maxBuffer: 1024 * 1024 * 1024 * configFile["training_max_buffer_size"] }, (err, stdout, stderr) => {
         if (stdout) {

--- a/tests/formatRunOptionsHeader.test.js
+++ b/tests/formatRunOptionsHeader.test.js
@@ -1,0 +1,37 @@
+const formatRunOptionsHeader = require('../utils/formatRunOptionsHeader');
+
+describe('formatRunOptionsHeader Utility Unit Tests', () => {
+    it('renders every option as a labeled line inside a header block', () => {
+        const header = formatRunOptionsHeader({
+            task: 'detect',
+            epochs: 50,
+            device: 'cuda:0',
+        });
+
+        expect(header).toContain('# task: detect');
+        expect(header).toContain('# epochs: 50');
+        expect(header).toContain('# device: cuda:0');
+        expect(header.indexOf('# task: detect')).toBeLessThan(header.indexOf('# epochs: 50'));
+    });
+
+    it('renders missing/empty values as (none) instead of dropping the key', () => {
+        const header = formatRunOptionsHeader({
+            options: undefined,
+            device: null,
+            weights: '',
+        });
+
+        expect(header).toContain('# options: (none)');
+        expect(header).toContain('# device: (none)');
+        expect(header).toContain('# weights: (none)');
+    });
+
+    it('produces a header that can be safely prepended before the run command', () => {
+        const header = formatRunOptionsHeader({ task: 'train' });
+        const cmd = 'python3 script.py -t train';
+        const logContents = `${header}${cmd}`;
+
+        expect(logContents.startsWith('# ===== Run options')).toBe(true);
+        expect(logContents.endsWith(cmd)).toBe(true);
+    });
+});

--- a/tests/integration/inferenceRunListing.test.js
+++ b/tests/integration/inferenceRunListing.test.js
@@ -1,0 +1,99 @@
+// Wrap the real implementation in a jest.fn() so we can assert the live route actually calls
+// it (a spy attached after require would miss the reference getInferencePage.js already
+// destructured at module load time).
+jest.mock('../../utils/isRunArtifactFile', () => {
+  const actual = jest.requireActual('../../utils/isRunArtifactFile');
+  return {
+    isCocoClassesFile: actual.isCocoClassesFile,
+    isReservedInferenceFile: jest.fn(actual.isReservedInferenceFile),
+  };
+});
+
+// getInferencePage.js does `const fs = require("fs")`, so the module-level mock (not a
+// global.fs assignment) is what actually reaches it.
+jest.mock('fs', () => ({
+  existsSync: jest.fn().mockReturnValue(true),
+  mkdirSync: jest.fn(),
+  writeFile: jest.fn((p, data, cb) => cb(null)),
+  readFileSync: jest.fn().mockReturnValue(''),
+  readdir: jest.fn((p, cb) => cb(null, [])),
+  readFile: jest.fn((p, cb) => cb(null, '')),
+}));
+
+const { isReservedInferenceFile } = require('../../utils/isRunArtifactFile');
+const getInferencePage = require('../../routes/pages/getInferencePage');
+
+describe('GET /inference page handler - coco-classes filtering', () => {
+  beforeEach(() => {
+    global.currentPath = '/test/path/';
+    global.util = require('util');
+    global.logger = { info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    global.configFile = {};
+
+    global.db = {
+      allAsync: jest.fn().mockResolvedValue([
+        { PName: 'test-project', Admin: 'testuser', Username: 'testuser' },
+      ]),
+      getAsync: jest.fn().mockResolvedValue({
+        PDescription: 'Test project description',
+        AutoSave: 1,
+      }),
+    };
+
+    global.sqlite3 = {
+      Database: jest.fn((dbPath, cb) => {
+        if (typeof cb === 'function') cb(null);
+        return {
+          get: jest.fn((sql, cb2) => cb2(null, {})),
+          all: jest.fn((sql, cb2) => cb2(null, [])),
+          close: jest.fn((cb2) => cb2 && cb2(null)),
+        };
+      }),
+    };
+
+    // One inference run whose artifact directory contains both a coco_classes.yaml
+    // (must be filtered out of the weights listing) and a real weight file (must stay).
+    const inferenceRunFiles = ['1700000000.log', 'done.log', 'coco_classes.yaml', 'best.pt'];
+
+    global.readdirAsync = jest.fn((dirPath) => {
+      if (typeof dirPath === 'string' && dirPath.endsWith('/inference/logs/')) {
+        return Promise.resolve(['1700000000']);
+      }
+      if (typeof dirPath === 'string' && dirPath.includes('/inference/logs/')) {
+        return Promise.resolve(inferenceRunFiles);
+      }
+      // weights dir, uploads dir, training logs dir, python scripts dir, etc.
+      return Promise.resolve([]);
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('excludes coco_classes.yaml from the rendered inference weights list, keeps real weights', async () => {
+    const req = { query: { IDX: '0' }, cookies: { Username: 'testuser' } };
+    const res = {
+      render: jest.fn(),
+      redirect: jest.fn(),
+    };
+
+    await getInferencePage(req, res);
+
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(res.render).toHaveBeenCalledTimes(1);
+
+    const [view, locals] = res.render.mock.calls[0];
+    expect(view).toBe('inference');
+
+    // The shared filter must have been asked about coco_classes.yaml and said "exclude".
+    const filenamesChecked = isReservedInferenceFile.mock.calls.map(([name]) => name);
+    expect(filenamesChecked).toContain('coco_classes.yaml');
+    expect(isReservedInferenceFile('coco_classes.yaml')).toBe(true);
+
+    // And the actual rendered weights list reflects that: coco_classes.yaml is gone,
+    // the real weight file survives.
+    expect(locals.weights_names_inf.flat()).not.toContain('coco_classes.yaml');
+    expect(locals.weights_names_inf.flat()).toContain('best.pt');
+  });
+});

--- a/tests/integration/yoloInference.test.js
+++ b/tests/integration/yoloInference.test.js
@@ -1,0 +1,135 @@
+// Set up global sqlite3 mock before requiring app
+jest.mock('decompress-zip', () => jest.fn());
+jest.mock('decompress-zip/lib/extractors', () => ({
+  folder: jest.fn(),
+}));
+jest.mock('ffmpeg', () => jest.fn());
+jest.mock('sharp', () => jest.fn());
+jest.mock('unzipper', () => jest.fn());
+jest.mock('child_process', () => ({
+  exec: jest.fn(),
+}));
+jest.mock('sqlite3', () => {
+  const mockSqlite3 = {
+    OPEN_CREATE: 1,
+    OPEN_READWRITE: 2,
+    OPEN_READONLY: 1,
+    Database: jest.fn((...args) => {
+      const cb = args[1];
+      if (typeof cb === 'function') cb(null);
+      return {
+        run: jest.fn((...cbArgs) => {
+          const cb = cbArgs[cbArgs.length - 1];
+          if (typeof cb === 'function') cb(null);
+          return { lastID: 1, changes: 1 };
+        }),
+        get: jest.fn((...cbArgs) => {
+          const cb = cbArgs[cbArgs.length - 1];
+          if (typeof cb === 'function') cb(null, {});
+        }),
+        all: jest.fn((...cbArgs) => {
+          const cb = cbArgs[cbArgs.length - 1];
+          if (typeof cb === 'function') cb(null, []);
+        }),
+        close: jest.fn((cb) => cb && cb()),
+      };
+    }),
+  };
+  mockSqlite3.verbose = jest.fn(() => mockSqlite3);
+  return mockSqlite3;
+});
+jest.mock('socket.io-client', () => ({
+  protocol: 'http',
+}));
+
+// Mock probe module
+jest.mock('probe-image-size', () => ({
+  sync: jest.fn(() => ({ width: 800, height: 600 })),
+}));
+
+global.sqlite3 = require('sqlite3');
+
+const request = require('supertest');
+const app = require('../../app');
+
+// Mock queries
+jest.mock('../../queries/queries', () => ({
+  project: {
+    getAllClasses: jest.fn().mockResolvedValue({ rows: [{ CName: 'class1' }] }),
+    getAllImages: jest.fn().mockResolvedValue({ rows: [] }),
+  },
+}));
+
+// Mock fs module - capture writeFileSync calls for assertions
+jest.mock('fs', () => ({
+  existsSync: jest.fn().mockReturnValue(true),
+  mkdirSync: jest.fn(),
+  writeFile: jest.fn((path, data, callback) => callback(null)),
+  writeFileSync: jest.fn(),
+  copyFileSync: jest.fn(),
+  symlinkSync: jest.fn(),
+  readdirSync: jest.fn().mockReturnValue([]),
+  readFileSync: jest.fn().mockReturnValue(''),
+}));
+
+// Mock file upload
+jest.mock('express-fileupload', () => jest.fn(() => (req, res, next) => {
+  next();
+}));
+
+// Mock Client
+jest.mock('../../queries/client', () => ({
+  Client: jest.fn().mockImplementation(() => ({})),
+}));
+
+describe('POST /yolo-inf - run options log header', () => {
+  beforeAll(() => {
+    global.currentPath = '/test/path/';
+    global.projectDbClients = {};
+    global.fs = require('fs');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prepends the user-chosen run options to the run log before the command', async () => {
+    const fs = require('fs');
+
+    const res = await request(app)
+      .post('/yolo-inf')
+      .send({
+        PName: 'test-project',
+        Admin: 'testuser',
+        yolovx_path: '/opt/ultralytics',
+        inference_file: '/test/path/public/projects/testuser-test-project/inference/uploads/img.jpg',
+        device: 'cpu',
+        options: '--conf 0.25',
+        yolo_task: 'detect',
+        weights: 'best.pt',
+      })
+      .set('Cookie', ['Username=testuser']);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ Success: 'YOLO Inference Started' });
+
+    // The route writes an empty placeholder to the run log first, then overwrites it with the
+    // header + command once the run is ready to start - take the last write to that log path.
+    const logWriteCalls = fs.writeFileSync.mock.calls.filter(
+      ([filePath]) => typeof filePath === 'string' && /\d+\.log$/.test(filePath),
+    );
+    const logWriteCall = logWriteCalls[logWriteCalls.length - 1];
+
+    expect(logWriteCall).toBeDefined();
+    const [, contents] = logWriteCall;
+
+    // Header must appear before the reproducing command, and must capture what the user chose
+    expect(contents.indexOf('# ===== Run options')).toBe(0);
+    expect(contents).toContain('# task: detect');
+    expect(contents).toContain('# device: cpu');
+    expect(contents).toContain('# options: --conf 0.25');
+    expect(contents).toContain('# weights: best.pt');
+    expect(contents).toContain('python3');
+    expect(contents.indexOf('# task: detect')).toBeLessThan(contents.indexOf('python3'));
+  });
+});

--- a/tests/isRunArtifactFile.test.js
+++ b/tests/isRunArtifactFile.test.js
@@ -1,0 +1,39 @@
+const { isReservedInferenceFile, isCocoClassesFile } = require('../utils/isRunArtifactFile');
+
+describe('isRunArtifactFile Utility Unit Tests', () => {
+    describe('isCocoClassesFile', () => {
+        it.each([
+            'coco_classes.yaml',
+            'coco-classes.txt',
+            'COCO_CLASSES.yaml',
+            'cocoClasses.yaml',
+        ])('flags "%s" as a coco-classes file', (fileName) => {
+            expect(isCocoClassesFile(fileName)).toBe(true);
+        });
+
+        it.each([
+            'best.pt',
+            'done.log',
+            '1699999999.log',
+            'classes.txt',
+        ])('does not flag "%s" as a coco-classes file', (fileName) => {
+            expect(isCocoClassesFile(fileName)).toBe(false);
+        });
+    });
+
+    describe('isReservedInferenceFile', () => {
+        it('still filters the pre-existing reserved script/output entries', () => {
+            expect(isReservedInferenceFile('datatovalues.py')).toBe(true);
+            expect(isReservedInferenceFile('output')).toBe(true);
+        });
+
+        it('filters coco-classes files out of inference run listings', () => {
+            expect(isReservedInferenceFile('coco_classes.yaml')).toBe(true);
+        });
+
+        it('leaves normal run artifacts (e.g. weights) in the listing', () => {
+            expect(isReservedInferenceFile('best.pt')).toBe(false);
+            expect(isReservedInferenceFile('1699999999.log')).toBe(false);
+        });
+    });
+});

--- a/utils/formatRunOptionsHeader.js
+++ b/utils/formatRunOptionsHeader.js
@@ -1,0 +1,16 @@
+function formatRunOptionsHeader(options) {
+    const lines = Object.entries(options).map(([key, value]) => {
+        const displayValue = value === undefined || value === null || value === "" ? "(none)" : value;
+        return `# ${key}: ${displayValue}`;
+    });
+
+    return [
+        "# ===== Run options (for reproducing this run) =====",
+        ...lines,
+        "# ====================================================",
+        "",
+        "",
+    ].join("\n");
+}
+
+module.exports = formatRunOptionsHeader;

--- a/utils/isRunArtifactFile.js
+++ b/utils/isRunArtifactFile.js
@@ -1,0 +1,12 @@
+const RESERVED_INFERENCE_FILES = new Set(["datatovalues.py", "output"]);
+const COCO_CLASSES_PATTERN = /coco[-_]?classes/i;
+
+function isCocoClassesFile(fileName) {
+    return COCO_CLASSES_PATTERN.test(fileName);
+}
+
+function isReservedInferenceFile(fileName) {
+    return RESERVED_INFERENCE_FILES.has(fileName) || isCocoClassesFile(fileName);
+}
+
+module.exports = { isReservedInferenceFile, isCocoClassesFile };


### PR DESCRIPTION
## Summary
- At the start of each training/inference run's log file, write a header block listing the options the user chose (task, model params, device, weights, freeform options, etc.) so the run can be reproduced from the log alone. Applies to `yolo-run`, `yolo-inf`, `inception-inf`, and the legacy `run` endpoint.
- The backend now filters `coco_classes.yaml` (and similarly-named coco-classes files) out of inference run listings on the training/inference/processing pages, alongside the pre-existing `datatovalues.py`/`output` filtering.

## Test plan
- [x] `npx jest` — full suite passes except one pre-existing, unrelated failure in `tests/logger.test.js` (a Windows path-parsing quirk in `utils/logger.js`, not touched by this change).
- [x] New unit tests: `tests/formatRunOptionsHeader.test.js`, `tests/isRunArtifactFile.test.js`.
- [x] New integration tests: `tests/integration/yoloInference.test.js` (asserts the header is written before the run command), `tests/integration/inferenceRunListing.test.js` (asserts `coco_classes.yaml` is excluded from rendered weights while real weight files remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)