### PR TITLE
fix: KW Coco archive import fails on filenames without trailing digits

### DIFF
--- a/controllers/imports/import_options.py
+++ b/controllers/imports/import_options.py
@@ -1,7 +1,6 @@
 import sys
 print("Python executable:", sys.executable);
 import os
-from ultralytics import YOLO
 from PIL import Image
 import subprocess
 import shutil
@@ -105,6 +104,8 @@ def classification_plus_import(db_name, input_dir, output):
 
 
 def inference_into_classification(db_name, input_dir, output, weights_file, classification_dir):
+    from ultralytics import YOLO
+
     print("\n--- Starting Inference into Classification ---")
     print(f"Input directory: {input_dir}")
     print(f"Weights file: {weights_file}")
@@ -203,6 +204,8 @@ def inference_into_classification(db_name, input_dir, output, weights_file, clas
     classification_plus_import(db_name, import_source_dir, output)
 
 def inference_plus_import(input_dir, output, weights_file):
+    from ultralytics import YOLO
+
     model = YOLO(weights_file)
 
     with open('labels.txt', "w") as f:
@@ -488,40 +491,50 @@ def coco_archive_import(db_name, input_dir, output, weights_file=None):
 
     import re
 
-    # helper function to extract trailing digits from a filename stem
+    # helper function to extract trailing digits from a filename stem, used only
+    # as a fallback when no file on disk has the exact name the JSON expects
     def get_digits_suffix(filename):
         stem = os.path.splitext(os.path.basename(filename))[0]
         match = re.search(r'(\d+)\s*$', stem)
 
         return int(match.group(1)) if match else None
 
-    # map the isolated integer frame number to its actual disk path
-    all_files_in_archive = {}
+    # index files on disk both by exact basename (matches what the KW COCO
+    # exporter writes as `file_name`) and by trailing frame number (fallback
+    # for archives from other tools that renamed files but kept the JSON in sync)
+    files_by_name = {}
+    files_by_frame_num = {}
     for root, dirs, files in os.walk(input_dir):
         if '__MACOSX' in root or '.pytest_cache' in root:
             continue
 
         for file in files:
             if file.lower().endswith(('.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff')):
+                full_path = os.path.join(root, file)
+                files_by_name[file] = full_path
+
                 frame_num = get_digits_suffix(file)
-
                 if frame_num is not None:
-                    all_files_in_archive[frame_num] = os.path.join(root, file)
+                    files_by_frame_num[frame_num] = full_path
 
-    print(f"Indexed {len(all_files_in_archive)} physical image stems via numeric frame matching.")
+    print(f"Indexed {len(files_by_name)} physical image files on disk.")
 
     for img_entry in coco_images:
         img_id = img_entry.get('id')
         file_name = img_entry.get('file_name')
 
         base_filename = os.path.basename(file_name)
-        target_frame_num = get_digits_suffix(base_filename)
+        found_path = files_by_name.get(base_filename)
 
-        print(f"Attempting to match JSON target '{base_filename}' using frame number ID: {target_frame_num}")
+        if found_path is None:
+            # fall back to matching on the trailing numeric frame number
+            target_frame_num = get_digits_suffix(base_filename)
+            found_path = files_by_frame_num.get(target_frame_num) if target_frame_num is not None else None
 
-        if target_frame_num in all_files_in_archive:
-            found_path = all_files_in_archive[target_frame_num]
+            if found_path is not None:
+                print(f"No exact filename match for '{base_filename}'; matched via frame number {target_frame_num} instead.")
 
+        if found_path is not None:
             # use the actual filename from the JSON so the bounding boxes stay consistent
             new_image_name = base_filename
 
@@ -531,7 +544,7 @@ def coco_archive_import(db_name, input_dir, output, weights_file=None):
             cursor.execute("INSERT OR IGNORE INTO Images (IName, reviewImage, validateImage) VALUES (?, 0, 0)", (new_image_name,))
             image_id_to_new_name[img_id] = new_image_name
         else:
-            print(f"FATAL ERROR: Frame ID '{target_frame_num}' from JSON entry '{base_filename}' cannot be matched to any file on disk.", file=sys.stderr)
+            print(f"FATAL ERROR: JSON entry '{base_filename}' cannot be matched to any file on disk.", file=sys.stderr)
             sys.exit(1)
 
     # 5. populate labels

--- a/tests/integration/cocoImportRoundTrip.test.js
+++ b/tests/integration/cocoImportRoundTrip.test.js
@@ -1,0 +1,98 @@
+// This suite runs the REAL controllers/imports/import_options.py (no
+// child_process/fs mocking), because the KW Coco archive-import bug only
+// shows up when the actual Python file-matching logic executes. The other
+// coco import tests in projects.test.js mock the python spawn entirely, so
+// they can't catch a regression here.
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const sqlite3 = require('sqlite3');
+
+const IMPORT_SCRIPT = path.join(__dirname, '..', '..', 'controllers', 'imports', 'import_options.py');
+
+function findPython() {
+  for (const candidate of ['python3', 'python']) {
+    const result = spawnSync(candidate, ['--version']);
+    if (result.status === 0) return candidate;
+  }
+  throw new Error('No python interpreter found on PATH');
+}
+
+// Builds a fixture that mirrors exactly what routes/downloads/downloadDataset.js
+// writes for downloadFormat == 2 (KW Coco): each image is archived under its
+// literal IName, and image["file_name"] in the JSON is that same literal name.
+function writeKwCocoFixture(dir, imageName) {
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Minimal valid JPEG bytes are not required — the importer only reads
+  // dimensions via PIL when parsing YOLO label files, not for COCO import.
+  fs.writeFileSync(path.join(dir, imageName), Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+
+  const cocoJson = {
+    images: [{ id: 1, file_name: imageName, width: 10, height: 10 }],
+    annotations: [{ id: 1, image_id: 1, category_id: 1, bbox: [1, 1, 5, 5] }],
+    categories: [{ id: 1, name: 'cat' }],
+  };
+  fs.writeFileSync(path.join(dir, 'project_coco.json'), JSON.stringify(cocoJson));
+}
+
+describe('KW Coco archive round trip (real python import)', () => {
+  let python;
+  let tmpRoot;
+
+  beforeAll(() => {
+    python = findPython();
+  });
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kwcoco-roundtrip-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('imports a KW Coco archive whose image name has no trailing digit suffix', async () => {
+    const inputDir = path.join(tmpRoot, 'input');
+    const outputDir = path.join(tmpRoot, 'output');
+    writeKwCocoFixture(inputDir, 'cat.jpg');
+
+    const result = spawnSync(python, [
+      IMPORT_SCRIPT,
+      '-i', inputDir,
+      '-o', outputDir,
+      '-d', 'testdb',
+      '-r', 'coco',
+    ], { encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(path.join(outputDir, 'images', 'cat.jpg'))).toBe(true);
+
+    const db = new sqlite3.Database(path.join(outputDir, 'testdb.db'), sqlite3.OPEN_READONLY);
+    const row = await new Promise((resolve, reject) => {
+      db.get('SELECT IName FROM Images WHERE IName = ?', ['cat.jpg'], (err, r) => {
+        db.close();
+        if (err) reject(err); else resolve(r);
+      });
+    });
+    expect(row).toBeTruthy();
+  });
+
+  it('still imports a KW Coco archive whose image name ends in digits', () => {
+    const inputDir = path.join(tmpRoot, 'input');
+    const outputDir = path.join(tmpRoot, 'output');
+    writeKwCocoFixture(inputDir, 'frame_001.jpg');
+
+    const result = spawnSync(python, [
+      IMPORT_SCRIPT,
+      '-i', inputDir,
+      '-o', outputDir,
+      '-d', 'testdb',
+      '-r', 'coco',
+    ], { encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(path.join(outputDir, 'images', 'frame_001.jpg'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `coco_archive_import()` in `controllers/imports/import_options.py` matched images to COCO JSON entries by extracting a trailing numeric suffix from the filename, but the KW Coco exporter (`routes/downloads/downloadDataset.js`, `downloadFormat == 2`) writes `image["file_name"]` as the literal image name and archives the image under that same exact name. Any image without trailing digits (e.g. `cat.jpg`) had no frame number to match on, hitting the importer's `FATAL ERROR` path and failing the whole import — so every downloaded-then-reimported KW Coco archive broke.
- Now matches on the exact basename first (what the exporter guarantees), falling back to the digit-suffix heuristic only when no exact match exists on disk.
- Lazy-loads `ultralytics`/`YOLO` (moved from module scope into the two functions that actually use it) so `import_options.py` can be imported and its COCO-import path exercised without pulling in the full YOLO/torch dependency chain — this is what makes the new test runnable at all.

Related: `controllers/imports/import_kwcoco.py` is a dead stub (the import route calls `import_options.py -r coco`, not this file) — flagged for a follow-up cleanup, not touched here.

## Test plan
- [x] New `tests/integration/cocoImportRoundTrip.test.js` runs the real Python importer (no mocked `spawn`/archive) against a fixture shaped exactly like the exporter's output, covering both a plain filename (`cat.jpg`) and a digit-suffixed one (`frame_001.jpg`); both pass with the fix.
- [x] Verified the new tests fail against the pre-fix code (`ModuleNotFoundError`/exit 1), confirming they catch the regression.
- [x] `npx jest` run locally — no new failures introduced; pre-existing unrelated failures (missing `config.json`, a Windows path-separator assertion in `logger.test.js`) are present on `main` too.